### PR TITLE
fix: spelling correction

### DIFF
--- a/_includes/layouts/home.njk
+++ b/_includes/layouts/home.njk
@@ -23,7 +23,7 @@ section: home
         <nav aria-label="social navigation">
             <ul>
                 <li><a href="https://dribbble.com/hustlepizza">Dribbble</a></li>
-                <li><a href="https://github.com/bradleytaunt">Github</a></li>
+                <li><a href="https://github.com/bradleytaunt">GitHub</a></li>
                 <li><a href="https://codepen.io/bradleytaunt/">CodePen</a></li>
                 <li><a href="https://twitter.com/bradtaunt">Twitter</a></li>
             </ul>


### PR DESCRIPTION
- Fix spelling of `GitHub` from `Github`